### PR TITLE
Visualize price jumps on candlestick chart

### DIFF
--- a/price_jump_eval_colab.py
+++ b/price_jump_eval_colab.py
@@ -1,0 +1,86 @@
+# price_jump_eval_colab.py
+"""Коллаб-ячейка: загрузка чекпойнта, расчёт предсказаний,
+сохранение данных для визуализации (без вывода графика).
+"""
+from pathlib import Path
+
+import json
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import Dataset, DataLoader
+
+# ─── ПАРАМЕТРЫ ────────────────────────────────────────────────────
+EVAL_JSON = Path("candles_2d.json")   # файл свечей для теста
+MODEL_PATH = Path("lstm_jump.pt")     # обученная модель
+OUT_DATA = Path("viz_data.npz")       # куда сохранить данные
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+# ──────────────────────────────────────────────────────────────────
+
+SEQ_LEN, PRED_WIN = 60, 25
+
+def load_df(path: Path) -> pd.DataFrame:
+    with open(path) as f:
+        raw = json.load(f)
+    df = pd.DataFrame(list(raw.values()))
+    df["datetime"] = pd.to_datetime(df["x"], unit="s")
+    return df.set_index("datetime").sort_index()
+
+class EvalDS(Dataset):
+    def __init__(self, df: pd.DataFrame, scaler: StandardScaler):
+        feats = df[["o", "h", "l", "c"]].astype(np.float32).values
+        self.x = scaler.transform(feats)
+        self.samples = [self.x[i-SEQ_LEN:i] for i in range(SEQ_LEN, len(df)-PRED_WIN)]
+    def __len__(self): return len(self.samples)
+    def __getitem__(self, idx): return torch.tensor(self.samples[idx])
+
+class LSTMCls(nn.Module):
+    def __init__(self, nfeat: int = 4, hidden: int = 64, layers: int = 2):
+        super().__init__(); self.lstm = nn.LSTM(nfeat, hidden, layers, batch_first=True); self.fc = nn.Linear(hidden, 2)
+    def forward(self, x): _, (h, _) = self.lstm(x); return self.fc(h[-1])
+
+print("Читаем", EVAL_JSON)
+df = load_df(EVAL_JSON)
+print(f"Загружено {len(df)} свечей")
+
+print("Загружаем модель", MODEL_PATH)
+ckpt = torch.load(MODEL_PATH, map_location=DEVICE, weights_only=False)
+model = LSTMCls(); model.load_state_dict(ckpt["model_state"]); model.to(DEVICE).eval()
+scaler: StandardScaler = ckpt["scaler"]
+
+loader = DataLoader(EvalDS(df, scaler), batch_size=512)
+preds = np.zeros(len(loader.dataset), dtype=np.int8)
+probs = np.zeros(len(loader.dataset), dtype=np.float32)
+
+print("Делаем предсказания...")
+with torch.no_grad():
+    ptr = 0
+    for xb in loader:
+        outputs = model(xb.to(DEVICE))
+        probs_batch = torch.softmax(outputs, dim=1).cpu().numpy()
+        p = outputs.argmax(1).cpu().numpy().astype(np.int8)
+        preds[ptr:ptr+len(p)] = p
+        probs[ptr:ptr+len(p)] = probs_batch[:, 1]  # вероятность класса 1
+        ptr += len(p)
+
+print(f"Сделано {len(preds)} предсказаний")
+print(f"Предсказаний 0: {np.sum(preds == 0)}")
+print(f"Предсказаний 1: {np.sum(preds == 1)}")
+print(f"Процент предсказаний 1: {np.mean(preds == 1)*100:.2f}%")
+print(f"Средняя уверенность модели: {np.mean(probs):.3f}")
+print(f"Мин/макс уверенность: {np.min(probs):.3f} / {np.max(probs):.3f}")
+
+print("Сохраняем", OUT_DATA)
+np.savez_compressed(
+    OUT_DATA,
+    index=df.index.astype("int64").values,
+    o=df["o"].values.astype(np.float32),
+    h=df["h"].values.astype(np.float32),
+    l=df["l"].values.astype(np.float32),
+    c=df["c"].values.astype(np.float32),
+    preds=preds,
+    probs=probs,
+)
+print("✓ Данные сохранены:", OUT_DATA)

--- a/price_jump_eval_colab.py
+++ b/price_jump_eval_colab.py
@@ -20,6 +20,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 # ──────────────────────────────────────────────────────────────────
 
 SEQ_LEN, PRED_WIN = 20, 5
+THRESHOLD = 0.45  # порог вероятности для присвоения класса 1
 
 def load_df(path: Path) -> pd.DataFrame:
     with open(path) as f:
@@ -61,7 +62,7 @@ with torch.no_grad():
     for xb in loader:
         outputs = model(xb.to(DEVICE))
         probs_batch = torch.softmax(outputs, dim=1).cpu().numpy()
-        p = outputs.argmax(1).cpu().numpy().astype(np.int8)
+        p = (probs_batch[:, 1] > THRESHOLD).astype(np.int8)
         preds[ptr:ptr+len(p)] = p
         probs[ptr:ptr+len(p)] = probs_batch[:, 1]  # вероятность класса 1
         ptr += len(p)

--- a/price_jump_eval_colab.py
+++ b/price_jump_eval_colab.py
@@ -20,7 +20,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 # ──────────────────────────────────────────────────────────────────
 
 SEQ_LEN, PRED_WINDOW = 20, 5
-THRESHOLD = 0.45  # порог вероятности для присвоения класса 1
+THRESHOLD = 0.8   # порог вероятности для присвоения класса 1
 
 def load_df(path: Path) -> pd.DataFrame:
     with open(path) as f:

--- a/price_jump_eval_colab.py
+++ b/price_jump_eval_colab.py
@@ -19,7 +19,7 @@ OUT_DATA = Path("viz_data.npz")       # куда сохранить данные
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 # ──────────────────────────────────────────────────────────────────
 
-SEQ_LEN, PRED_WIN = 60, 25
+SEQ_LEN, PRED_WIN = 20, 5
 
 def load_df(path: Path) -> pd.DataFrame:
     with open(path) as f:

--- a/price_jump_eval_colab.py
+++ b/price_jump_eval_colab.py
@@ -32,7 +32,8 @@ class EvalDS(Dataset):
     def __init__(self, df: pd.DataFrame, scaler: StandardScaler):
         feats = df[["o", "h", "l", "c"]].astype(np.float32).values
         self.x = scaler.transform(feats)
-        self.samples = [self.x[i-SEQ_LEN:i] for i in range(SEQ_LEN, len(df)-PRED_WIN)]
+        # Последовательности включают текущую свечу (индекс i)
+        self.samples = [self.x[i - SEQ_LEN + 1 : i + 1] for i in range(SEQ_LEN, len(df) - PRED_WIN)]
     def __len__(self): return len(self.samples)
     def __getitem__(self, idx): return torch.tensor(self.samples[idx])
 

--- a/price_jump_eval_colab.py
+++ b/price_jump_eval_colab.py
@@ -19,7 +19,7 @@ OUT_DATA = Path("viz_data.npz")       # куда сохранить данные
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 # ──────────────────────────────────────────────────────────────────
 
-SEQ_LEN, PRED_WIN = 20, 5
+SEQ_LEN, PRED_WINDOW = 20, 5
 THRESHOLD = 0.45  # порог вероятности для присвоения класса 1
 
 def load_df(path: Path) -> pd.DataFrame:
@@ -34,12 +34,11 @@ class EvalDS(Dataset):
         raw_feats = df[["o", "h", "l", "c"]].astype(np.float32).values
 
         windows = []
-        for i in range(SEQ_LEN, len(df) - PRED_WIN):
+        for i in range(SEQ_LEN, len(df) - PRED_WINDOW):
             window_raw = raw_feats[i - SEQ_LEN + 1 : i + 1].copy()
             ref_open   = window_raw[0, 0]
             window_rel = window_raw / ref_open - 1.0
-            window_scaled = scaler.transform(window_rel)
-            windows.append(window_scaled)
+            windows.append(scaler.transform(window_rel))
 
         self.samples = windows
     def __len__(self): return len(self.samples)

--- a/price_jump_train_colab.py
+++ b/price_jump_train_colab.py
@@ -25,14 +25,16 @@ class CandleDataset(Dataset):
         feats = self.scaler.transform(feats)
 
         self.samples=[]
-        for i in range(SEQ_LEN, len(df)-PRED_WINDOW):
+        # Формируем выборку: последовательность включает текущую свечу (индекс i)
+        for i in range(SEQ_LEN, len(df) - PRED_WINDOW):
             current_open = self.opens[i]
             # Максимум Close за следующие 5 минут
-            max_close = self.closes[i+1:i+PRED_WINDOW+1].max()
+            max_close = self.closes[i + 1 : i + PRED_WINDOW + 1].max()
             # Проверяем, превышает ли максимум open на 0.35%
             jump = (max_close / current_open - 1) >= JUMP_THRESHOLD
             label = 1 if jump else 0
-            self.samples.append((feats[i-SEQ_LEN:i], label))
+            # Последовательность длиной SEQ_LEN, включающая текущую свечу
+            self.samples.append((feats[i - SEQ_LEN + 1 : i + 1], label))
 
     def __len__(self): return len(self.samples)
     def __getitem__(self, idx):

--- a/price_jump_train_colab.py
+++ b/price_jump_train_colab.py
@@ -8,7 +8,7 @@ import json, numpy as np, pandas as pd, torch, torch.nn as nn
 from sklearn.preprocessing import StandardScaler
 from torch.utils.data import Dataset, DataLoader, random_split
 
-SEQ_LEN, PRED_WINDOW, JUMP_THRESHOLD = 20, 5, 0.0035   # 20-мин история, окно 5 мин, 0.35%
+SEQ_LEN, PRED_WINDOW, JUMP_THRESHOLD = 20, 5, 0.0035  # 20-мин история, окно 5 мин
 
 def load_dataframe(path: Path) -> pd.DataFrame:
     with open(path) as f: raw = json.load(f)

--- a/price_jump_train_colab.py
+++ b/price_jump_train_colab.py
@@ -1,0 +1,88 @@
+# price_jump_train_colab.py
+"""Обучает LSTM, метка = 1 если
+   • максимум Close за следующие 5 мин ≥ Open + 0.35%
+Сохраняет модель и StandardScaler в lstm_jump.pt
+"""
+from pathlib import Path
+import json, numpy as np, pandas as pd, torch, torch.nn as nn
+from sklearn.preprocessing import StandardScaler
+from torch.utils.data import Dataset, DataLoader, random_split
+
+SEQ_LEN, PRED_WINDOW, JUMP_THRESHOLD = 60, 25, 0.0035   # 20-мин история, окно 5 мин, 0.35%
+
+def load_dataframe(path: Path) -> pd.DataFrame:
+    with open(path) as f: raw = json.load(f)
+    df = pd.DataFrame(list(raw.values()))
+    df["datetime"] = pd.to_datetime(df["x"], unit="s")
+    return df.set_index("datetime").sort_index()
+
+class CandleDataset(Dataset):
+    def __init__(self, df: pd.DataFrame):
+        self.closes = df["c"].astype(np.float32).values
+        self.opens = df["o"].astype(np.float32).values
+        feats = df[["o","h","l","c"]].astype(np.float32).values
+        self.scaler = StandardScaler().fit(feats)
+        feats = self.scaler.transform(feats)
+
+        self.samples=[]
+        for i in range(SEQ_LEN, len(df)-PRED_WINDOW):
+            current_open = self.opens[i]
+            # Максимум Close за следующие 5 минут
+            max_close = self.closes[i+1:i+PRED_WINDOW+1].max()
+            # Проверяем, превышает ли максимум open на 0.35%
+            jump = (max_close / current_open - 1) >= JUMP_THRESHOLD
+            label = 1 if jump else 0
+            self.samples.append((feats[i-SEQ_LEN:i], label))
+
+    def __len__(self): return len(self.samples)
+    def __getitem__(self, idx):
+        x,y = self.samples[idx]
+        return torch.tensor(x), torch.tensor(y)
+
+class LSTMClassifier(nn.Module):
+    def __init__(self,nfeat=4,hidden=64,layers=2):
+        super().__init__(); self.lstm=nn.LSTM(nfeat,hidden,layers,batch_first=True); self.fc=nn.Linear(hidden,2)
+    def forward(self,x): _,(h,_) = self.lstm(x); return self.fc(h[-1])
+
+# ─── параметры обучения ───────────────────────────────────────────
+TRAIN_JSON = Path("candles_10d.json")
+MODEL_PATH = Path("lstm_jump.pt")
+VAL_SPLIT, EPOCHS = 0.2, 10
+BATCH_SIZE, LR = 512, 1e-3
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+print("Загружаем", TRAIN_JSON)
+
+df = load_dataframe(TRAIN_JSON)
+print(f"Загружено {len(df)} свечей")
+
+ds = CandleDataset(df)
+print(f"Создано {len(ds)} сэмплов")
+print(f"Меток 1: {sum(1 for _, y in ds.samples if y == 1)}")
+print(f"Меток 0: {sum(1 for _, y in ds.samples if y == 0)}")
+
+val = int(len(ds)*VAL_SPLIT)
+train_ds,val_ds = random_split(ds,[len(ds)-val,val])
+tl = DataLoader(train_ds,BATCH_SIZE,shuffle=True)
+vl = DataLoader(val_ds,BATCH_SIZE)
+
+model = LSTMClassifier().to(DEVICE)
+opt   = torch.optim.Adam(model.parameters(), LR)
+lossf = nn.CrossEntropyLoss()
+
+for e in range(1, EPOCHS+1):
+    model.train(); tot=0
+    for x,y in tl:
+        x,y = x.to(DEVICE), y.to(DEVICE)
+        opt.zero_grad(); loss=lossf(model(x),y); loss.backward(); opt.step()
+        tot += loss.item()*x.size(0)
+    model.eval(); corr=tot_s=0
+    with torch.no_grad():
+        for x,y in vl:
+            p=model(x.to(DEVICE)).argmax(1).cpu()
+            corr+=(p==y).sum().item(); tot_s+=y.size(0)
+    print(f'Epoch {e}/{EPOCHS} loss {tot/len(train_ds):.4f} val_acc {corr/tot_s:.3f}')
+
+MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+torch.save({"model_state":model.state_dict(),"scaler":ds.scaler}, MODEL_PATH)
+print("✓ Модель сохранена в", MODEL_PATH.resolve())

--- a/price_jump_train_colab.py
+++ b/price_jump_train_colab.py
@@ -8,7 +8,7 @@ import json, numpy as np, pandas as pd, torch, torch.nn as nn
 from sklearn.preprocessing import StandardScaler
 from torch.utils.data import Dataset, DataLoader, random_split
 
-SEQ_LEN, PRED_WINDOW, JUMP_THRESHOLD = 60, 25, 0.0035   # 20-мин история, окно 5 мин, 0.35%
+SEQ_LEN, PRED_WINDOW, JUMP_THRESHOLD = 20, 5, 0.0035   # 20-мин история, окно 5 мин, 0.35%
 
 def load_dataframe(path: Path) -> pd.DataFrame:
     with open(path) as f: raw = json.load(f)

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -46,7 +46,7 @@ fig, axlist = mpf.plot(dfp, **kw, returnfig=True)
 if vdates:
     price_ax = axlist[0]  # основная ось с ценой
     for vd in vdates:
-        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.10,
+        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.12,
                          linewidth=1.2, alpha=0.8)
 
 import matplotlib.pyplot as plt

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -45,9 +45,19 @@ fig, axlist = mpf.plot(dfp, **kw, returnfig=True)
 # Добавляем короткие вертикальные линии (0–10 % высоты оси цены)
 if vdates:
     price_ax = axlist[0]  # основная ось с ценой
+    y_min, y_max = price_ax.get_ylim()
+    margin = (y_max - y_min) * 0.02  # отступ 2 % от цены
+
+    # Индекс без таймзоны для удобного поиска цен
+    df_no_tz = dfp.copy()
+    df_no_tz.index = df_no_tz.index.tz_localize(None)
+
     for vd in vdates:
-        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.05,
-                         linewidth=1.2, alpha=0.8)
+        # Цена минимума текущей свечи
+        low_price = df_no_tz.loc[vd, "Low"]
+        top_y = max(y_min, low_price - margin)
+        price_ax.vlines(vd, y_min, top_y,
+                        colors="blue", linewidth=1.2, alpha=0.8)
 
 import matplotlib.pyplot as plt
 plt.show()

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -36,7 +36,7 @@ kw = dict(type="candle", style="charles", volume=False,
 if not jumps.empty:
     vdates = list(jumps.index.tz_localize(None))
     # Рисуем короткие вертикальные отрезки в нижней части графика (0-10% высоты)
-    kw["vlines"] = dict(vlines=vdates, ymin=0.0, ymax=0.10, colors="red", linewidths=1.2, alpha=0.8)
+    kw["vlines"] = dict(vlines=vdates, ymin=0.0, ymax=0.10, colors="blue", linewidths=1.2, alpha=0.8)
 
 print("Рисуем график…")
 mpf.plot(dfp, **kw)

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -33,12 +33,21 @@ dfp = df.rename(columns={"o": "Open", "h": "High", "l": "Low", "c": "Close"})
 
 kw = dict(type="candle", style="charles", volume=False,
           show_nontrading=True, datetime_format="%m-%d %H:%M", xrotation=15)
-if not jumps.empty:
-    vdates = list(jumps.index.tz_localize(None))
-    # Рисуем короткие вертикальные отрезки в нижней части графика (0-10% высоты)
-    kw["vlines"] = dict(vlines=vdates, ymin=0.0, ymax=0.10, colors="blue", linewidths=1.2, alpha=0.8)
+
+# Сохраняем даты скачков без таймзоны для последующего рисования
+vdates = list(jumps.index.tz_localize(None)) if not jumps.empty else []
 
 print("Рисуем график…")
-mpf.plot(dfp, **kw)
+
+# Рисуем график и получаем фигуру для последующего добавления линий
+fig, axlist = mpf.plot(dfp, **kw, returnfig=True)
+
+# Добавляем короткие вертикальные линии (0–10 % высоты оси цены)
+if vdates:
+    price_ax = axlist[0]  # основная ось с ценой
+    for vd in vdates:
+        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.10,
+                         linewidth=1.2, alpha=0.8)
+
 import matplotlib.pyplot as plt
 plt.show()

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -1,0 +1,43 @@
+# price_jump_visualize.py
+"""Загружает файл viz_data.npz, сформированный скриптом price_jump_eval_colab.py,
+и строит свечной график с отметками прогнозируемых скачков.
+"""
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import mplfinance as mpf
+
+# ─── НАСТРОЙКА ──────────────────────────────────────────────────────
+DATA_FILE = Path("viz_data.npz")   # путь к файлу с сохранёнными данными
+# ───────────────────────────────────────────────────────────────────
+
+print("Читаем", DATA_FILE)
+npz = np.load(DATA_FILE)
+
+# Восстанавливаем DataFrame
+idx = pd.to_datetime(npz["index"], utc=True)
+
+df = pd.DataFrame({
+    "o": npz["o"],
+    "h": npz["h"],
+    "l": npz["l"],
+    "c": npz["c"],
+}, index=idx)
+
+preds = pd.Series(npz["preds"], index=idx[20:20 + len(npz["preds"])] )
+
+# Подготовка для mplfinance
+jumps = preds[preds == 1]
+dfp = df.rename(columns={"o": "Open", "h": "High", "l": "Low", "c": "Close"})
+
+kw = dict(type="candle", style="charles", volume=False,
+          show_nontrading=True, datetime_format="%m-%d %H:%M", xrotation=15)
+if not jumps.empty:
+    vdates = list(jumps.index.tz_localize(None))
+    kw["vlines"] = vdates
+
+print("Рисуем график…")
+mpf.plot(dfp, **kw)
+import matplotlib.pyplot as plt
+plt.show()

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -46,7 +46,7 @@ fig, axlist = mpf.plot(dfp, **kw, returnfig=True)
 if vdates:
     price_ax = axlist[0]  # основная ось с ценой
     for vd in vdates:
-        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.98,
+        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.05,
                          linewidth=1.2, alpha=0.8)
 
 import matplotlib.pyplot as plt

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -35,7 +35,8 @@ kw = dict(type="candle", style="charles", volume=False,
           show_nontrading=True, datetime_format="%m-%d %H:%M", xrotation=15)
 if not jumps.empty:
     vdates = list(jumps.index.tz_localize(None))
-    kw["vlines"] = vdates
+    # Рисуем короткие вертикальные отрезки в нижней части графика (0-10% высоты)
+    kw["vlines"] = dict(vlines=vdates, ymin=0.0, ymax=0.10, colors="red", linewidths=1.2, alpha=0.8)
 
 print("Рисуем график…")
 mpf.plot(dfp, **kw)

--- a/price_jump_visualize.py
+++ b/price_jump_visualize.py
@@ -46,7 +46,7 @@ fig, axlist = mpf.plot(dfp, **kw, returnfig=True)
 if vdates:
     price_ax = axlist[0]  # основная ось с ценой
     for vd in vdates:
-        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.12,
+        price_ax.axvline(vd, color="blue", ymin=0.0, ymax=0.98,
                          linewidth=1.2, alpha=0.8)
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Add `price_jump_visualize.py` script to visualize predicted price jumps on a candlestick chart.

---
<a href="https://cursor.com/background-agent?bcId=bc-85a8c51c-19fc-48c2-92da-240f5a26b76a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85a8c51c-19fc-48c2-92da-240f5a26b76a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

